### PR TITLE
react-native-sound replaced with react-native-track-player

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,14 +1,31 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import PlayerScreen from './screens/PlayerScreen/PlayerScreen';
 import { StatusBar } from 'expo-status-bar';
 import { PlayerProvider } from './contexts/PlayerContext';
 import AlbumsScreen from './screens/AlbumsScreen/AlbumsScreen';
+import setupPlayer from "./utils/setupPlayer";
 
 const Stack = createStackNavigator();
 
 export default function App() {
+  const [playerInitialized, setPlayerInitialized] = useState(false);
+  
+  useEffect(() => {
+    const initializePlayer = async () => {
+      try {
+        if(!playerInitialized){
+          await setupPlayer();
+          setPlayerInitialized(true)
+        }
+      } catch (error) {
+        console.error('Error setting up player', error);
+      }
+    };
+    initializePlayer();
+  }, []);
+
   return (
     <PlayerProvider>
       <StatusBar hidden={true}/>

--- a/contexts/PlayerContext.jsx
+++ b/contexts/PlayerContext.jsx
@@ -6,16 +6,19 @@ export const PlayerContext = createContext();
 export const PlayerProvider = ({ children }) => {
     const [albumMode, setAlbumMode] = useState(true);
     const [playList, setPlaylist] = useState({ items: [] });
+    const [playingIndex, setPlayingIndex] = useState(0);
+    const [onShuffle, setOnShuffle] = useState(false);
 
     const heightAnim = useRef(new Animated.Value(350)).current;
     const progressBarOpacity = useRef(new Animated.Value(0)).current;
     const albumItemsOpacity = useRef(new Animated.Value(1)).current;
     const footerHeightAnim = useRef(new Animated.Value(80)).current;
 
-    const formatTime = (milliseconds) => {
-        const minutes = Math.floor(milliseconds / 60000);
-        const seconds = Math.floor((milliseconds % 60000) / 1000);
-        return `${minutes}:${seconds < 10 ? '0' : ''}${seconds}`;
+    const formatTime = (totalSeconds) => {
+        const minutes = Math.floor(totalSeconds / 60);
+        const seconds = Math.floor(totalSeconds % 60);
+        const formattedSeconds = seconds < 10 ? `0${seconds}` : seconds;
+        return `${minutes}:${formattedSeconds}`;
     };
 
     const panResponder = useRef(
@@ -36,7 +39,11 @@ export const PlayerProvider = ({ children }) => {
             albumItemsOpacity,
             footerHeightAnim,
             panResponder,
-            formatTime
+            formatTime,
+            playingIndex,
+            setPlayingIndex,
+            onShuffle,
+            setOnShuffle
         }}>
             {children}
         </PlayerContext.Provider>

--- a/contexts/PlayerContext.jsx
+++ b/contexts/PlayerContext.jsx
@@ -1,27 +1,16 @@
-import React, { createContext, useState, useRef, useEffect } from 'react';
-import { Animated, PanResponder, ToastAndroid } from 'react-native';
-import Sound from 'react-native-sound';
-import ServiceProvider from '../libs/APIParser';
+import React, { createContext, useState, useRef } from 'react';
+import { Animated, PanResponder } from 'react-native';
 
 export const PlayerContext = createContext();
 
 export const PlayerProvider = ({ children }) => {
     const [albumMode, setAlbumMode] = useState(true);
-    const [playingIndex, setPlayingIndex] = useState(0);
-    const [currentDuration, setCurrentDuration] = useState(0);
-    const [totalDuration, setTotalDuration] = useState(0);
-    const [isPlaying, setIsPlaying] = useState(false);
-    const [onShuffle, setOnShuffle] = useState(false);
-    const [onRepeat, setOnRepeat] = useState(false);
     const [playList, setPlaylist] = useState({ items: [] });
 
-    const soundRef = useRef(null);
-    const intervalRef = useRef(null);
     const heightAnim = useRef(new Animated.Value(350)).current;
     const progressBarOpacity = useRef(new Animated.Value(0)).current;
     const albumItemsOpacity = useRef(new Animated.Value(1)).current;
     const footerHeightAnim = useRef(new Animated.Value(80)).current;
-    const serviceProvider = new ServiceProvider();
 
     const formatTime = (milliseconds) => {
         const minutes = Math.floor(milliseconds / 60000);
@@ -38,118 +27,15 @@ export const PlayerProvider = ({ children }) => {
         })
     ).current;
 
-    const getRandomIndex = () => {
-        return Math.floor(Math.random() * (playList.items.length || 0));
-    };
-
-    const updateDuration = () => {
-        if (soundRef.current) {
-            soundRef.current.getCurrentTime(seconds => {
-                setCurrentDuration(seconds * 1000);
-            });
-        }
-    };
-
-    const playSound = async () => {
-        if (soundRef.current) {
-            soundRef.current.release();
-            soundRef.current = null;
-        }
-
-        const playUrl = await serviceProvider.playByMediaUrl(playList.items[playingIndex]?.playUrl);
-
-        if (playUrl) {
-            const newSound = new Sound(playUrl, Sound.MAIN_BUNDLE, (error) => {
-                if (error) {
-                    ToastAndroid.show(error, ToastAndroid.LONG);
-                    return;
-                }
-
-                setTotalDuration(newSound.getDuration() * 1000);
-
-                newSound.play((success) => {
-                    if (success) {
-                        handlePlaybackFinish();
-                    } else {
-                        ToastAndroid.show('Playback failed due to audio decoding errors', ToastAndroid.SHORT);
-                    }
-                });
-
-                soundRef.current = newSound;
-                setIsPlaying(true);
-
-                if (intervalRef.current) {
-                    clearInterval(intervalRef.current);
-                }
-                intervalRef.current = setInterval(updateDuration, 1000);
-            });
-
-            newSound.setNumberOfLoops(onRepeat ? -1 : 0);
-        } else {
-            ToastAndroid.show('Play URL is not set', ToastAndroid.SHORT);
-        }
-    };
-
-    const handlePlaybackFinish = () => {
-        clearInterval(intervalRef.current);
-
-        const nextIndex = onShuffle
-            ? getRandomIndex()
-            : (playingIndex + 1) % (playList.items.length || 1);
-
-        setPlayingIndex(nextIndex);
-    };
-
-    const pauseSound = () => {
-        if (soundRef.current && isPlaying) {
-            soundRef.current.pause();
-            setIsPlaying(false);
-            clearInterval(intervalRef.current);
-        }
-    };
-
-    const stopSound = () => {
-        if (soundRef.current) {
-            soundRef.current.stop(() => {
-                setIsPlaying(false);
-                clearInterval(intervalRef.current);
-            });
-        }
-    };
-
-    useEffect(() => {
-        return () => {
-            if (soundRef.current) {
-                soundRef.current.release();
-            }
-            clearInterval(intervalRef.current);
-        };
-    }, []);
-
-    useEffect(() => {
-        if (isPlaying) {
-            playSound();
-        }
-    }, [playingIndex, isPlaying]);
-
     return (
         <PlayerContext.Provider value={{
             albumMode, setAlbumMode,
-            playingIndex, setPlayingIndex,
-            currentDuration, setCurrentDuration,
-            totalDuration,
-            isPlaying, setIsPlaying,
-            onShuffle, setOnShuffle,
-            onRepeat, setOnRepeat,
             playList, setPlaylist,
             heightAnim,
             progressBarOpacity,
             albumItemsOpacity,
             footerHeightAnim,
             panResponder,
-            playSound,
-            pauseSound,
-            stopSound,
             formatTime
         }}>
             {children}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "@react-navigation/stack": "^6.4.1",
     "axios": "^1.7.3",
     "expo": "~51.0.26",
-    "expo-av": "~14.0.6",
     "expo-status-bar": "~1.12.1",
     "html-entities": "^2.5.2",
     "react": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "react-native-safe-area-context": "4.10.5",
     "react-native-screens": "3.31.1",
     "react-native-snap-carousel": "^3.9.1",
-    "react-native-sound": "^0.11.2",
     "react-native-svg": "^15.2.0",
     "react-native-track-player": "^4.1.1",
     "react-native-vector-icons": "^10.1.0",

--- a/screens/AlbumsScreen/components/Card.jsx
+++ b/screens/AlbumsScreen/components/Card.jsx
@@ -7,7 +7,7 @@ import { PlayerContext } from '../../../contexts/PlayerContext';
 import { useNavigation } from '@react-navigation/native';
 
 const Card = ({ albumData, index }) => {
-    const { setPlayingIndex, setPlaylist, playList, playSound, stopSound } = useContext(PlayerContext);
+    const { setPlaylist } = useContext(PlayerContext);
     const navigation = useNavigation();
     return (
         <TouchableOpacity onPress={() => handleAlbum({

--- a/screens/PlayerScreen/PlayerScreen.jsx
+++ b/screens/PlayerScreen/PlayerScreen.jsx
@@ -2,7 +2,7 @@ import {
     StyleSheet,
     View,
 } from "react-native";
-import React, { useContext } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { useNavigation } from "@react-navigation/native";
 import { PlayerContext } from '../../contexts/PlayerContext';
 import PlayerFooter from "./components/PlayerFooter";
@@ -10,29 +10,153 @@ import PlayerBanner from "./components/PlayerBanner";
 import AlbumItemsContainer from "./components/AlbumItemsContainer";
 import ProgressBarContainer from "./components/ProgressBarContainer";
 import DurationText from "./components/DurationText";
+import TrackPlayer, { Event, State, useTrackPlayerEvents } from "react-native-track-player";
+import { decode } from 'html-entities';
+import ServiceProvider from '../../libs/APIParser';
 
 const PlayerScreen = () => {
     const {
-        albumMode,
+        albumMode, playList, setPlayingIndex, playingIndex, onShuffle, setOnShuffle
     } = useContext(PlayerContext);
+
+    const serviceProvider = new ServiceProvider();
+    const [totalDuration, setTotalDuration] = useState(0);
+    const [currentDuration, setCurrentDuration] = useState(0);
+    const [playState, setPlayState] = useState(State.None);
+
+    const playurlOverrider = async (index) => {
+        const trackPlayerQueue = await TrackPlayer.getQueue()
+        trackPlayerQueue[index].url = await serviceProvider.playByMediaUrl(trackPlayerQueue[index]?.url)
+        await TrackPlayer.reset();
+        await TrackPlayer.add(trackPlayerQueue);
+        await TrackPlayer.skip(index);
+        await TrackPlayer.play();
+        setPlayingIndex(index);
+    };
+
+    const nextActionOverrider = async() => {
+        const repeatMode = await TrackPlayer.getRepeatMode();
+        if(onShuffle){
+            await playurlOverrider(Math.floor(Math.random() * playList.items.length));
+        }
+        else if (repeatMode!==0){
+            await playurlOverrider(playingIndex);
+        }
+        else {
+            await playurlOverrider(playingIndex < playList.items.length - 1 ? playingIndex + 1 : 0)
+        }
+    }
+
+    const previousActionOverrider = async() => {
+        const repeatMode = await TrackPlayer.getRepeatMode();
+        if (onShuffle) {
+            await playurlOverrider(Math.floor(Math.random() * playList.items.length));
+        }
+        else if (repeatMode!==0) {
+            await playurlOverrider(playingIndex);
+        }
+        else {
+            await playurlOverrider(playingIndex > 0 ? playingIndex - 1 : playList.items.length - 1)
+        }
+    }
+
+    useEffect(() => {
+        const addTracks = async () => {
+            await TrackPlayer.reset();
+            for (const [index, item] of playList.items.entries()) {
+                const reparsedItem = {
+                    id: index,
+                    url: item.playUrl,
+                    title: decode(item.songName),
+                    artwork: item.songCover,
+                    artist: playList.artistName,
+                };
+                await TrackPlayer.add(reparsedItem);
+            }
+            await TrackPlayer.seekTo(0);
+            setTotalDuration(1);
+            setCurrentDuration(0);
+            setPlayingIndex(0);
+        };
+        addTracks();
+    }, [playList]);
+
+    useTrackPlayerEvents([Event.PlaybackState], async (event)=>{
+        setPlayState(event.state);
+    })
+
+    useTrackPlayerEvents([Event.PlaybackProgressUpdated], async (event) => {
+        setTotalDuration(event.duration);
+        setCurrentDuration(event.position);
+        if(event.duration-event.position<5){
+            await nextActionOverrider();
+        }
+
+        if ((event.buffered - event.position < 5) && (event.duration - event.position>5)){
+            await TrackPlayer.pause();
+        }else{
+            await TrackPlayer.play();
+        }
+    })
+
+    // useTrackPlayerEvents([Event.PlaybackActiveTrackChanged], async (event) => {
+    //     if (event.type === Event.PlaybackActiveTrackChanged && event.index === undefined) {
+    //         await playurlOverrider(0);
+    //         return;
+    //     }
+
+    //     if (event.type === Event.PlaybackActiveTrackChanged && event.index !== null && event.index !== playingIndex) {
+    //         console.log(`Track changed to index: ${event.index}`);
+    //         await playurlOverrider(event.index);
+    //     }
+    // });
+
+    useTrackPlayerEvents([Event.PlaybackQueueEnded], async () => {
+        const repeatMode = await TrackPlayer.getRepeatMode();
+
+        if (repeatMode === 0) {
+            await nextActionOverrider();
+        } else {
+            await TrackPlayer.seekTo(0);
+            await playurlOverrider(playingIndex);
+        }
+    });
+
+    useTrackPlayerEvents([Event.RemoteNext], async () => {
+        await nextActionOverrider();
+    });
+    
+    useTrackPlayerEvents([Event.RemotePrevious], async () => {
+        await previousActionOverrider();
+    });
+
+    useTrackPlayerEvents([Event.RemotePlay], async () => {
+        await playurlOverrider(playingIndex);
+    });
+
+    useTrackPlayerEvents([Event.RemoteSeek], async (event) => {
+        if (event.position !== undefined) {
+            await TrackPlayer.seekTo(event.position);
+        }
+    });
 
     const navigation = useNavigation();
 
     return (
         <View style={styles.container}>
-            <PlayerBanner />
+            <PlayerBanner playingIndex={playingIndex} playList={playList} />
             {
                 albumMode
                     ? (
-                        <AlbumItemsContainer />
+                        <AlbumItemsContainer playList={playList} playurlOverrider={playurlOverrider} />
                     ) : (
                         <>
-                            <ProgressBarContainer />
-                            <DurationText />
+                            <ProgressBarContainer totalDuration={totalDuration} currentDuration={currentDuration}/>
+                            <DurationText currentDuration={currentDuration}/>
                         </>
                     )
             }
-            <PlayerFooter />
+            <PlayerFooter playState={playState} onShuffle={onShuffle} setOnShuffle={setOnShuffle} playingIndex={playingIndex} playurlOverrider={playurlOverrider} nextActionOverrider={nextActionOverrider} previousActionOverrider={previousActionOverrider} />
         </View>
     );
 };

--- a/screens/PlayerScreen/components/AlbumItemsContainer.jsx
+++ b/screens/PlayerScreen/components/AlbumItemsContainer.jsx
@@ -1,87 +1,81 @@
-import { Animated, StyleSheet, Text, View } from 'react-native'
-import React, { useContext, useEffect } from 'react'
+import { Animated, StyleSheet, Text, View } from 'react-native';
+import React, { useContext, useEffect } from 'react';
 import { FlatList, TouchableOpacity } from 'react-native-gesture-handler';
 import { PlayerContext } from '../../../contexts/PlayerContext';
 import { Easing } from 'react-native-reanimated';
-import { decode } from "html-entities";
-const AlbumItemsContainer = () => {
-    const { formatTime, albumItemsOpacity, albumMode, playList } = useContext(PlayerContext);
-    const playingIndex = 1
-    useEffect(()=>{
+import { decode } from 'html-entities';
+import TrackPlayer from 'react-native-track-player';
+
+const AlbumItemsContainer = ({ playList, playurlOverrider }) => {
+    const { formatTime, albumItemsOpacity, albumMode, playingIndex, setPlayingIndex } = useContext(PlayerContext);
+
+    useEffect(() => {
         Animated.timing(albumItemsOpacity, {
             toValue: albumMode ? 1 : 0,
             duration: 400,
             useNativeDriver: true,
             easing: Easing.ease,
         }).start();
-    }, [albumMode])
+    }, [albumMode]);
 
-    const onItemPlayPressed = (index) => {
-        console.log(`item pressed ${index}`);
-    }
+    const onItemPlayPressed = async (index) => {        
+        await playurlOverrider(index);
+    };
 
     const renderAlbumItems = ({ item, index }) => (
-        <TouchableOpacity onPress={()=>onItemPlayPressed(index)}>
+        <TouchableOpacity onPress={() => onItemPlayPressed(index)}>
             <View style={styles.albumItems}>
                 <Text
                     style={[
                         styles.songItem,
-                        index === playingIndex
-                            ? { fontWeight: "800" }
-                            : { fontWeight: "500" },
+                        index === playingIndex ? { fontWeight: '800' } : { fontWeight: '500' },
                     ]}
                 >
-                    {
-                    decode(item.songName.length) > 30
-                            ? `${decode(item.songName).substring(0,30)}...`
-                    : decode(item.songName)
-                    }
+                    {decode(item.songName).length > 30
+                        ? `${decode(item.songName).substring(0, 30)}...`
+                        : decode(item.songName)}
                 </Text>
                 <Text
                     style={[
                         styles.songItem,
-                        index === playingIndex
-                            ? { fontWeight: "800" }
-                            : { fontWeight: "500" },
+                        index === playingIndex ? { fontWeight: '800' } : { fontWeight: '500' },
                     ]}
                 >
-                    {formatTime(item.duration*1000)}
+                    {formatTime(item.duration)}
                 </Text>
             </View>
         </TouchableOpacity>
     );
 
-  return (
-      <Animated.View
-          style={[styles.albumItemsContainer, { opacity: albumItemsOpacity }]}
-      >
-          <FlatList
-              data={playList.items}
-              renderItem={renderAlbumItems}
-              keyExtractor={(item, index) => index.toString()}
-          />
-      </Animated.View>
-  )
-}
+    return (
+        <Animated.View style={[styles.albumItemsContainer, { opacity: albumItemsOpacity }]}>
+            <FlatList
+                data={playList.items}
+                renderItem={renderAlbumItems}
+                keyExtractor={(item, index) => index.toString()}
+            />
+        </Animated.View>
+    );
+};
 
-export default AlbumItemsContainer
+export default AlbumItemsContainer;
 
 const styles = StyleSheet.create({
     albumItems: {
-        flexDirection: "row",
-        minWidth: "100%",
-        alignItems: "center",
-        justifyContent: "space-between",
+        flexDirection: 'row',
+        minWidth: '100%',
+        alignItems: 'center',
+        justifyContent: 'space-between',
         paddingVertical: 10,
         paddingHorizontal: 40,
     },
     albumItemsContainer: {
         maxHeight: 300,
         marginTop: 40,
-        overflow: "scroll",
+        overflow: 'scroll',
     },
     songItem: {
         fontSize: 15,
-        fontWeight: "500",
+        fontWeight: '500',
     },
-})
+});

--- a/screens/PlayerScreen/components/AlbumItemsContainer.jsx
+++ b/screens/PlayerScreen/components/AlbumItemsContainer.jsx
@@ -5,8 +5,8 @@ import { PlayerContext } from '../../../contexts/PlayerContext';
 import { Easing } from 'react-native-reanimated';
 import { decode } from "html-entities";
 const AlbumItemsContainer = () => {
-    const { setPlayingIndex, formatTime, playingIndex, albumItemsOpacity, albumMode, playList, playSound, stopSound } = useContext(PlayerContext);
-    
+    const { formatTime, albumItemsOpacity, albumMode, playList } = useContext(PlayerContext);
+    const playingIndex = 1
     useEffect(()=>{
         Animated.timing(albumItemsOpacity, {
             toValue: albumMode ? 1 : 0,
@@ -17,9 +17,7 @@ const AlbumItemsContainer = () => {
     }, [albumMode])
 
     const onItemPlayPressed = (index) => {
-        setPlayingIndex(index);
-        stopSound();
-        playSound();
+        console.log(`item pressed ${index}`);
     }
 
     const renderAlbumItems = ({ item, index }) => (

--- a/screens/PlayerScreen/components/DurationText.jsx
+++ b/screens/PlayerScreen/components/DurationText.jsx
@@ -2,9 +2,8 @@ import { StyleSheet, Text } from 'react-native'
 import React, { useContext } from 'react'
 import { PlayerContext } from '../../../contexts/PlayerContext';
 
-const DurationText = () => {
+const DurationText = ({currentDuration}) => {    
     const { formatTime } = useContext(PlayerContext);
-    const currentDuration = 200
     return (
         <Text style={styles.durationText}>{formatTime(currentDuration)}</Text>
     )

--- a/screens/PlayerScreen/components/DurationText.jsx
+++ b/screens/PlayerScreen/components/DurationText.jsx
@@ -3,7 +3,8 @@ import React, { useContext } from 'react'
 import { PlayerContext } from '../../../contexts/PlayerContext';
 
 const DurationText = () => {
-    const { currentDuration, formatTime } = useContext(PlayerContext);
+    const { formatTime } = useContext(PlayerContext);
+    const currentDuration = 200
     return (
         <Text style={styles.durationText}>{formatTime(currentDuration)}</Text>
     )

--- a/screens/PlayerScreen/components/PlayerBanner.jsx
+++ b/screens/PlayerScreen/components/PlayerBanner.jsx
@@ -4,9 +4,8 @@ import { PlayerContext } from '../../../contexts/PlayerContext'
 import { Easing } from 'react-native-reanimated';
 import { decode } from 'html-entities';
 
-const PlayerBanner = () => {
-    const playingIndex = 0
-    const { albumMode, heightAnim, panResponder, playList } = useContext(PlayerContext)
+const PlayerBanner = ({ playingIndex, playList }) => {
+    const { albumMode, heightAnim, panResponder } = useContext(PlayerContext)
     useEffect(() => {
         Animated.timing(heightAnim, {
             toValue: albumMode ? 350 : 500,

--- a/screens/PlayerScreen/components/PlayerBanner.jsx
+++ b/screens/PlayerScreen/components/PlayerBanner.jsx
@@ -5,7 +5,8 @@ import { Easing } from 'react-native-reanimated';
 import { decode } from 'html-entities';
 
 const PlayerBanner = () => {
-    const { albumMode, heightAnim, panResponder } = useContext(PlayerContext)
+    const playingIndex = 0
+    const { albumMode, heightAnim, panResponder, playList } = useContext(PlayerContext)
     useEffect(() => {
         Animated.timing(heightAnim, {
             toValue: albumMode ? 350 : 500,
@@ -22,7 +23,9 @@ const PlayerBanner = () => {
       >
           <ImageBackground
               source={
-                  "../../../assets/albumcover.png"
+                  albumMode
+                      ? { uri: playList.albumCover }
+                      : { uri: playList.items[playingIndex].songCover }
               }
               style={styles.image}
               resizeMode="cover"
@@ -30,9 +33,17 @@ const PlayerBanner = () => {
               <View style={styles.overlay} />
           </ImageBackground>
           <Text style={styles.text}>
-              album/song name
+              {albumMode
+                  ? decode(playList.albumName.length > 15
+                      ? `${playList.albumName.substring(0, 15)}...`
+                      : playList.albumName)
+                  : decode(playList.items[playingIndex].songName.length > 15
+                      ? `${playList.items[playingIndex].songName.substring(0, 15)}...`
+                      : playList.items[playingIndex].songName)}
           </Text>
-          <Text style={[styles.text, styles.subtext]}>artists name</Text>
+          <Text style={[styles.text, styles.subtext]}>{decode(playList.artistName.length > 15
+              ? `${playList.artistName.substring(0, 15)}...`
+              : playList.artistName)}</Text>
       </Animated.View>
   )
 }

--- a/screens/PlayerScreen/components/PlayerBanner.jsx
+++ b/screens/PlayerScreen/components/PlayerBanner.jsx
@@ -5,7 +5,7 @@ import { Easing } from 'react-native-reanimated';
 import { decode } from 'html-entities';
 
 const PlayerBanner = () => {
-    const { albumMode, heightAnim, panResponder, playList, playingIndex } = useContext(PlayerContext)
+    const { albumMode, heightAnim, panResponder } = useContext(PlayerContext)
     useEffect(() => {
         Animated.timing(heightAnim, {
             toValue: albumMode ? 350 : 500,
@@ -22,9 +22,7 @@ const PlayerBanner = () => {
       >
           <ImageBackground
               source={
-                  albumMode
-                      ? {uri: playList.albumCover}
-                      : {uri: playList.items[playingIndex].songCover}
+                  "../../../assets/albumcover.png"
               }
               style={styles.image}
               resizeMode="cover"
@@ -32,17 +30,9 @@ const PlayerBanner = () => {
               <View style={styles.overlay} />
           </ImageBackground>
           <Text style={styles.text}>
-              {albumMode
-                  ? decode(playList.albumName.length > 15
-                      ? `${playList.albumName.substring(0, 15)}...`
-                      : playList.albumName) 
-                  : decode(playList.items[playingIndex].songName.length > 15
-                      ? `${playList.items[playingIndex].songName.substring(0, 15)}...`
-                      : playList.items[playingIndex].songName)}
+              album/song name
           </Text>
-          <Text style={[styles.text, styles.subtext]}>{decode(playList.artistName.length > 15
-              ? `${playList.artistName.substring(0, 15)}...`
-              : playList.artistName)}</Text>
+          <Text style={[styles.text, styles.subtext]}>artists name</Text>
       </Animated.View>
   )
 }

--- a/screens/PlayerScreen/components/PlayerFooter.jsx
+++ b/screens/PlayerScreen/components/PlayerFooter.jsx
@@ -6,11 +6,11 @@ import Ionicons from "react-native-vector-icons/Ionicons";
 import { Easing } from 'react-native-reanimated';
 
 const PlayerFooter = () => {
+    const isPlaying = true
+    const onRepeat = true
+    const onShuffle = true
     const {
-        footerHeightAnim, setOnShuffle, onShuffle, albumMode,
-        setOnRepeat, onRepeat, isPlaying, setIsPlaying,
-        playSound, stopSound, pauseSound, sound,
-        playingIndex, setPlayingIndex, playList
+        footerHeightAnim, albumMode,
     } = useContext(PlayerContext);
 
     useEffect(() => {
@@ -22,59 +22,20 @@ const PlayerFooter = () => {
         }).start();
     }, [albumMode]);
 
-    useEffect(() => {
-        if (sound) {
-            playSound();
-        }
-    }, [playingIndex]);
 
     const handleOnRepeat = () => {
-        setOnRepeat(!onRepeat);
     };
 
     const handlePlayPause = async () => {
-        try {
-            if (isPlaying) {
-                await pauseSound();
-            } else if (sound) {
-                await sound.play();
-                setIsPlaying(true);
-            } else {
-                await playSound();
-            }
-        } catch (error) {
-            console.error("Error during play/pause operation:", error);
-        }
     };
 
     const handleOnShuffle = () => {
-        setOnShuffle(!onShuffle);
     };
 
     const handleOnNext = () => {
-        stopSound();
-        setPlayingIndex(prevIndex => {
-            if (onShuffle) {
-                return Math.floor(Math.random() * playList.items.length);
-            } else if (onRepeat) {
-                return prevIndex;
-            } else {
-                return prevIndex < playList.items.length - 1 ? prevIndex + 1 : 0;
-            }
-        });
     };
 
     const handleOnPrevious = () => {
-        stopSound();
-        setPlayingIndex(prevIndex => {
-            if (onShuffle) {
-                return Math.floor(Math.random() * playList.items.length);
-            } else if (onRepeat) {
-                return prevIndex;
-            } else {
-                return prevIndex > 0 ? prevIndex - 1 : playList.items.length - 1;
-            }
-        });
     };
 
     return (

--- a/screens/PlayerScreen/components/ProgressBarContainer.jsx
+++ b/screens/PlayerScreen/components/ProgressBarContainer.jsx
@@ -5,9 +5,7 @@ import { AnimatedCircularProgress } from 'react-native-circular-progress'
 import { Circle } from 'react-native-svg'
 import { Easing } from 'react-native-reanimated';
 
-const ProgressBarContainer = () => {
-    const currentDuration = 60
-    const totalDuration = 100
+const ProgressBarContainer = ({totalDuration, currentDuration}) => {
     const { albumMode, progressBarOpacity } = useContext(PlayerContext);
     useEffect(() => {
         Animated.timing(progressBarOpacity, {

--- a/screens/PlayerScreen/components/ProgressBarContainer.jsx
+++ b/screens/PlayerScreen/components/ProgressBarContainer.jsx
@@ -6,7 +6,9 @@ import { Circle } from 'react-native-svg'
 import { Easing } from 'react-native-reanimated';
 
 const ProgressBarContainer = () => {
-    const { progressBarOpacity, albumMode, currentDuration, totalDuration } = useContext(PlayerContext);
+    const currentDuration = 60
+    const totalDuration = 100
+    const { albumMode, progressBarOpacity } = useContext(PlayerContext);
     useEffect(() => {
         Animated.timing(progressBarOpacity, {
             toValue: albumMode ? 0 : 1,

--- a/utils/RNTPService.js
+++ b/utils/RNTPService.js
@@ -1,0 +1,6 @@
+import TrackPlayer, { Event } from 'react-native-track-player'
+
+export const RNTPService = async () => {
+    TrackPlayer.addEventListener(Event.RemotePlay, () => TrackPlayer.play())
+    TrackPlayer.addEventListener(Event.RemotePause, () => TrackPlayer.pause())
+}

--- a/utils/setupPlayer.js
+++ b/utils/setupPlayer.js
@@ -1,0 +1,27 @@
+import TrackPlayer, {
+    AppKilledPlaybackBehavior,
+    Capability,
+} from 'react-native-track-player'
+
+const setupPlayer = async () => {
+    await TrackPlayer.setupPlayer()
+
+    await TrackPlayer.updateOptions({
+        android: {
+            appKilledPlaybackBehavior:
+                AppKilledPlaybackBehavior.StopPlaybackAndRemoveNotification,
+            alwaysPauseOnInterruption: true,
+        },
+        capabilities: [
+            Capability.Play,
+            Capability.Pause,
+            Capability.SkipToNext,
+            Capability.SkipToPrevious,
+            Capability.SeekTo,
+        ],
+        compactCapabilities: [Capability.Play, Capability.Pause],
+        progressUpdateEventInterval: 1,
+    })        
+}
+
+export default setupPlayer


### PR DESCRIPTION
### Bloatware free
RNS does not have alot of hooks for managing state and hence i used context API to to share player state. That turned out to be a huge mistake as every duration change in the player was re-rendering whole router. *Skills issue? Maybe.*

### Solution
RNTP has more facilities to handle player than RNS. and, hence implemented as per requirement of issue #1.
Now, the context API is only used for basic and rare changing states. Rest is managed by RNTP hooks.